### PR TITLE
Add NFS Role 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 ansible.cfg-example
 inventory.yaml
+cluster.kubeconfig

--- a/inventory.yaml-example
+++ b/inventory.yaml-example
@@ -1,6 +1,10 @@
 # This is an example of a basic inventory file.  For full documention please see:
 # https://docs.ansible.com/ansible/latest/inventory_guide/intro_inventory.html
 ---
+all:
+  vars:
+    dedicated_nfs: true
+
 f8s:
   hosts:
     ## Set this to your Fedora host you want to install f8s on

--- a/inventory.yaml-example
+++ b/inventory.yaml-example
@@ -7,3 +7,13 @@ f8s:
     f8s.example.com:
       # Set this to the remote user with sudo permissions on the Fedora host
       ansible_user: fedora
+
+# For multi-node clusters
+workers:
+  hosts:
+    worker1.example.com:
+      ansible_user: fedora
+      container_runtime: crio
+    worker2.example.com:
+      ansible_user: fedora
+      container_runtime: crio

--- a/roles/kubernetes/tasks/main.yaml
+++ b/roles/kubernetes/tasks/main.yaml
@@ -3,6 +3,12 @@
   ansible.builtin.include_tasks: 
     file: packages.yaml
 
+- name: Ensure firewalld is running
+  ansible.builtin.systemd:
+    name: firewalld
+    state: started
+    enabled: true
+
 - name: Set up Firewall for Kubernetes
   ansible.posix.firewalld:
     port: "{{ item }}/tcp"
@@ -54,8 +60,15 @@
 
 - name: Initialize the Kubernetes cluster
   ansible.builtin.shell:
-  ignore_errors: true
     cmd: kubeadm init --pod-network-cidr=10.244.0.0/16
+  ignore_errors: true
+
+- name: Create the .kube directory
+  ansible.builtin.file:
+    path: "/home/{{ ansible_user }}/.kube"
+    state: directory
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
 
 - name: Copy kubeconfig to {{ ansible_user }}'s home directory
   ansible.builtin.copy:
@@ -65,17 +78,23 @@
     group: "{{ ansible_user }}"
     remote_src: true
 
-- name: Taint node {{ ansible_host }}
-  kubernetes.core.k8s_taint:
-    state: present
-    name: "{{ ansible_host }}"
-    taints:
-    - effect: Execute
+# - name: Taint node {{ ansible_host }} as master node
+#   kubernetes.core.k8s_taint:
+#     state: present
+#     name: "{{ ansible_host }}"
+#     taints:
+#       - key: node-role.kubernetes.io/master
+#         effect: PreferNoSchedule
+
+- name: Download Flannel YAML
+  get_url:
+    url: 'https://github.com/flannel-io/flannel/releases/latest/download/kube-flannel.yml'
+    dest: '/tmp/kube-flannel.yml'
 
 - name: Install Flannel (Layer 3 Network Fabric for Kubernetes)
   kubernetes.core.k8s:
     state: present
-    src: '{{ lookup("url", "https://github.com/flannel-io/flannel/releases/latest/download/kube-flannel.yml") }}'
+    src: '/tmp/kube-flannel.yml'
 
 # - name: Set up nfs storage class
 #   include_tasks: nfs.yaml

--- a/roles/kubernetes/tasks/main.yaml
+++ b/roles/kubernetes/tasks/main.yaml
@@ -93,28 +93,28 @@
     - groups['workers'] | length > 0
     - join_command is defined
 
-# - name: Set up nfs storage class
-#   include_tasks: nfs.yaml
-#   when: dedicated_nfs
+- name: Write kubeconfig to file on localhost
+  ansible.builtin.copy:
+    content: "{{ kubeconfig }}"
+    dest: cluster.kubeconfig
+  delegate_to: localhost
+  become: false
 
-- name: Make the kubeconfig easily accessible
-  when: kubeconfig is defined
-  block:
-    - name: Print kubeconfig contents with steps on how to configure it locally
-      ansible.builtin.debug:
-        msg: |
-          export KUBECONFIG={{ kubeconfig }}
+- name: Set up nfs storage class
+  include_role:
+    name: nfs-provisioner
+  vars:
+    kubeconfig_path: ./cluster.kubeconfig
+  when: dedicated_nfs
 
-    - name: Write kubeconfig to file on localhost
-      ansible.builtin.copy:
-        content: "{{ kubeconfig }}"
-        dest: cluster.kubeconfig
-      delegate_to: localhost
-      become: false
+- name: Print kubeconfig contents with steps on how to configure it locally
+  ansible.builtin.debug:
+    msg: |
+      export KUBECONFIG={{ kubeconfig }}
 
-    - name: Explain how to access the cluster
-      ansible.builtin.debug:
-        msg: |
-          To access the cluster, run the following command:
-          export KUBECONFIG={{ lookup('pipe','pwd') }}/cluster.kubeconfig
-          kubectl get nodes
+- name: Explain how to access the cluster
+  ansible.builtin.debug:
+    msg: |
+      To access the cluster, run the following command:
+      export KUBECONFIG={{ lookup('pipe','pwd') }}/cluster.kubeconfig
+      kubectl get nodes

--- a/roles/kubernetes/tasks/main.yaml
+++ b/roles/kubernetes/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Install packages
-  ansible.builtin.include_tasks: 
+  ansible.builtin.include_tasks:
     file: packages.yaml
 
 - name: Ensure firewalld is running
@@ -40,12 +40,19 @@
   ansible.builtin.shell:
     cmd: sysctl --system
 
+- name: Install crio
+  ansible.builtin.package:
+    name: crio
+    state: present
+  when: container_runtime == "crio"
+
+
 - name: Enable and start {{ container_runtime }} service
   ansible.builtin.systemd:
     name: "{{ container_runtime }}"
-    daemon_reload: yes
+    daemon_reload: true
     state: started
-    enabled: yes
+    enabled: true
 
 - name: Pull needed system container images for Kubernetes
   ansible.builtin.shell:
@@ -54,48 +61,60 @@
 - name: Enable and start kubernetes kubelet service
   ansible.builtin.systemd:
     name: kubelet
-    daemon_reload: yes
+    daemon_reload: true
     state: started
-    enabled: yes
+    enabled: true
 
-- name: Initialize the Kubernetes cluster
-  ansible.builtin.shell:
-    cmd: kubeadm init --pod-network-cidr=10.244.0.0/16
-  ignore_errors: true
+- name: Bootstrap master node
+  ansible.builtin.include_tasks:
+    file: master.yaml
+  when: inventory_hostname in groups['f8s']
 
-- name: Create the .kube directory
-  ansible.builtin.file:
-    path: "/home/{{ ansible_user }}/.kube"
-    state: directory
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user }}"
+- name: Bootstrap worker node
+  ansible.builtin.include_tasks:
+    file: worker.yaml
+  when:
+    - inventory_hostname in groups['workers']
+    - join_command is defined
 
-- name: Copy kubeconfig to {{ ansible_user }}'s home directory
-  ansible.builtin.copy:
-    src: /etc/kubernetes/admin.conf
-    dest: /home/{{ ansible_user }}/.kube/config
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user }}"
-    remote_src: true
-
-# - name: Taint node {{ ansible_host }} as master node
-#   kubernetes.core.k8s_taint:
-#     state: present
-#     name: "{{ ansible_host }}"
-#     taints:
-#       - key: node-role.kubernetes.io/master
-#         effect: PreferNoSchedule
-
-- name: Download Flannel YAML
-  get_url:
-    url: 'https://github.com/flannel-io/flannel/releases/latest/download/kube-flannel.yml'
-    dest: '/tmp/kube-flannel.yml'
-
-- name: Install Flannel (Layer 3 Network Fabric for Kubernetes)
+- name: Set labels on both worker nodes (run on f8s node)
   kubernetes.core.k8s:
     state: present
-    src: '/tmp/kube-flannel.yml'
+    definition:
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: "{{ item }}"
+        labels:
+          node-role.kubernetes.io/worker: ''
+  loop: "{{ groups['workers'] }}"
+  delegate_to: "{{ groups['f8s'][0] }}"
+  when:
+    - groups['workers'] | length > 0
+    - join_command is defined
 
 # - name: Set up nfs storage class
 #   include_tasks: nfs.yaml
 #   when: dedicated_nfs
+
+- name: Make the kubeconfig easily accessible
+  when: kubeconfig is defined
+  block:
+    - name: Print kubeconfig contents with steps on how to configure it locally
+      ansible.builtin.debug:
+        msg: |
+          export KUBECONFIG={{ kubeconfig }}
+
+    - name: Write kubeconfig to file on localhost
+      ansible.builtin.copy:
+        content: "{{ kubeconfig }}"
+        dest: cluster.kubeconfig
+      delegate_to: localhost
+      become: false
+
+    - name: Explain how to access the cluster
+      ansible.builtin.debug:
+        msg: |
+          To access the cluster, run the following command:
+          export KUBECONFIG={{ lookup('pipe','pwd') }}/cluster.kubeconfig
+          kubectl get nodes

--- a/roles/kubernetes/tasks/master.yaml
+++ b/roles/kubernetes/tasks/master.yaml
@@ -1,0 +1,67 @@
+---
+
+- name: Initialize the Kubernetes cluster
+  ansible.builtin.shell:
+    cmd: kubeadm init --pod-network-cidr=10.244.0.0/16
+  ignore_errors: true
+
+- name: Create the .kube directory
+  ansible.builtin.file:
+    path: "/home/{{ ansible_user }}/.kube"
+    state: directory
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+
+- name: Copy kubeconfig to {{ ansible_user }}'s home directory
+  ansible.builtin.copy:
+    src: /etc/kubernetes/admin.conf
+    dest: /home/{{ ansible_user }}/.kube/config
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    remote_src: true
+
+# - name: Taint node {{ ansible_host }} as master node
+#   kubernetes.core.k8s_taint:
+#     state: present
+#     name: "{{ ansible_host }}"
+#     taints:
+#       - key: node-role.kubernetes.io/master
+#         effect: PreferNoSchedule
+
+- name: Download Flannel YAML
+  ansible.builtin.get_url:
+    url: 'https://github.com/flannel-io/flannel/releases/latest/download/kube-flannel.yml'
+    dest: '/tmp/kube-flannel.yml'
+    mode: '0644'
+
+- name: Install Flannel (Layer 3 Network Fabric for Kubernetes)
+  kubernetes.core.k8s:
+    state: present
+    src: '/tmp/kube-flannel.yml'
+
+- name: Get the join command
+  ansible.builtin.shell:
+    cmd: kubeadm token create --print-join-command
+  register: join_command
+
+- name: Set join_command as a fact so it is available in worker tasks
+  ansible.builtin.set_fact:
+    join_command: "{{ join_command.stdout_lines[0] }}"
+    cacheable: true
+  delegate_to: localhost
+  run_once: true
+  when: join_command is defined
+
+- name: Get KUBECONFIG
+  ansible.builtin.shell:
+    cmd: cat "/home/{{ ansible_user }}/.kube/config"
+  register: kubeconfig
+  become: true
+
+- name: Set kubeconfig as a fact so it is available in worker tasks
+  ansible.builtin.set_fact:
+    kubeconfig: "{{ kubeconfig.stdout }}"
+    cacheable: true
+  delegate_to: localhost
+  run_once: true
+  when: kubeconfig is defined

--- a/roles/kubernetes/tasks/worker.yaml
+++ b/roles/kubernetes/tasks/worker.yaml
@@ -5,10 +5,6 @@
     msg: "{{ join_command }}"
   when: join_command is defined
 
-- name: Print host name
-  ansible.builtin.debug:
-    msg: "{{ ansible_host }}"
-
 - name: Use join command to join worker nodes to the cluster
   ansible.builtin.shell:
     cmd: "{{ join_command }}"

--- a/roles/kubernetes/tasks/worker.yaml
+++ b/roles/kubernetes/tasks/worker.yaml
@@ -1,0 +1,18 @@
+---
+
+- name: Print join command
+  ansible.builtin.debug:
+    msg: "{{ join_command }}"
+  when: join_command is defined
+
+- name: Print host name
+  ansible.builtin.debug:
+    msg: "{{ ansible_host }}"
+
+- name: Use join command to join worker nodes to the cluster
+  ansible.builtin.shell:
+    cmd: "{{ join_command }}"
+  when: join_command is defined
+  ignore_errors: true
+  register: join_output
+

--- a/roles/nfs-provisioner/README.md
+++ b/roles/nfs-provisioner/README.md
@@ -1,0 +1,41 @@
+# NFS Provisioner Role
+
+This Ansible role is used to install and configure the NFS provisioner in a Kubernetes cluster using Helm.
+
+* https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner
+
+## Prerequisites
+
+- Ansible
+- Helm
+- Kubernetes cluster
+
+## Usage
+
+1. Clone this repository to your local machine.
+2. Navigate to the directory containing the role.
+3. Run the playbook using the following command:
+
+```bash
+ansible-playbook configure-nfs-provisioner.yaml
+```
+
+## Role Tasks
+Here's what the role does:
+
+* Checks if Helm is installed, if not, it installs Helm.
+* Adds the NFS provisioner Helm repository.
+* Updates Helm repositories.
+* Checks if NFS provisioner is already installed.
+* If NFS provisioner is not installed, it installs the NFS provisioner using Helm.
+
+## Variables
+This role does not require any variables.  But a custom kubeconfig_path can be set to be used.
+
+* kubeconfig_path: /path/to/kubeconfig
+
+## Contributing
+If you want to contribute to this project, please submit a pull request.
+
+## License
+This project is licensed under the MIT License.

--- a/roles/nfs-provisioner/configure-nfs-provisioner.yaml
+++ b/roles/nfs-provisioner/configure-nfs-provisioner.yaml
@@ -1,0 +1,7 @@
+---
+- name: Install NFS StorageClass Provisioner using Helm
+  hosts: localhost
+  tasks:
+    - name: Include nfs-provisioner role
+      ansible.builtin.include_role:
+        name: ../nfs-provisioner

--- a/roles/nfs-provisioner/defaults/main.yml
+++ b/roles/nfs-provisioner/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+nfs_server: x.x.x.x
+nfs_path: /exported/path
+

--- a/roles/nfs-provisioner/files/helm-nfs-server-provisioner.yml
+++ b/roles/nfs-provisioner/files/helm-nfs-server-provisioner.yml
@@ -1,0 +1,5 @@
+storageClass:
+  create: true
+  defaultClass: false
+  name: nfs-local-rwx
+

--- a/roles/nfs-provisioner/tasks/main.yml
+++ b/roles/nfs-provisioner/tasks/main.yml
@@ -1,0 +1,62 @@
+---
+- name: Check if Helm is installed
+  ansible.builtin.command: helm version --short
+  register: helm_check
+  changed_when: False
+  ignore_errors: True
+  become: false
+  delegate_to: localhost
+
+- name: Install Helm if not installed
+  ansible.builtin.command: /bin/bash -c "curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash"
+  environment:
+    VERIFY_CHECKSUM: "false"  # This is needed if openssl is not installed
+  when: helm_check.failed
+  become: false
+  delegate_to: localhost
+
+- name: Add NFS provisioner Helm repository
+  ansible.builtin.command: helm repo add stable https://charts.helm.sh/stable
+  register: helm_repo_add
+  changed_when: "'Repository already exists' not in helm_repo_add.stdout"
+  become: false
+  delegate_to: localhost
+
+- name: Update Helm repositories
+  ansible.builtin.command: helm repo update
+  when: helm_repo_add.changed
+  become: false
+  delegate_to: localhost
+
+- name: Check if NFS provisioner is already installed
+  ansible.builtin.shell: >
+    helm list --deployed | grep nfs-provisioner
+  register: helm_check
+  ignore_errors: yes
+  environment:
+    KUBECONFIG: "{{ kubeconfig_path }}"
+  become: false
+  delegate_to: localhost
+
+- name: Print working directory and tree
+  ansible.builtin.command: >
+    pwd && tree
+  register: pwd_tree
+  environment:
+    KUBECONFIG: "{{ kubeconfig_path }}"
+  become: false
+  delegate_to: localhost
+
+- debug:
+    msg: "{{ role_path }}"
+
+- name: Install NFS provisioner using Helm
+  ansible.builtin.command: >
+    helm install nfs-provisioner stable/nfs-server-provisioner --values={{ role_path }}/files/helm-nfs-server-provisioner.yml
+  register: helm_install
+  failed_when: "'INSTALLATION FAILED: cannot re-use a name that is still in use' not in helm_install.stderr"
+  changed_when: "'already installed' not in helm_install.stdout"
+  environment:
+    KUBECONFIG: "{{ kubeconfig_path }}"
+  become: false
+  delegate_to: localhost


### PR DESCRIPTION
This adds a role to automatically provision an NFS storage class after the cluster comes up.  This is options and can be enabled/disabled by setting the following variable in your f8s inventory file:

```
---
all:
  vars:
    dedicated_nfs: true
```